### PR TITLE
feat: add inline mapper to append datetime columns

### DIFF
--- a/.github/workflows/manual_build.yml
+++ b/.github/workflows/manual_build.yml
@@ -33,5 +33,5 @@ jobs:
         run: meltano install
 
       - name: build pipeline
-        run: meltano run tap-spreadsheets-anywhere target-duckdb dbt-duckdb:build
+        run: meltano run tap-spreadsheets-anywhere add-timestamps target-duckdb dbt-duckdb:build
         

--- a/.github/workflows/pr_to_master.yml
+++ b/.github/workflows/pr_to_master.yml
@@ -28,6 +28,6 @@ jobs:
 
       - name: build pipeline
         run: |
-          meltano run tap-spreadsheets-anywhere target-duckdb --full-refresh
+          meltano run tap-spreadsheets-anywhere add-timestamps target-duckdb --full-refresh
           meltano invoke dbt-duckdb run-operation elo_rollforward
           meltano run dbt-duckdb:build

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@ build:
 	meltano install
 
 run:
-	meltano run tap-spreadsheets-anywhere target-duckdb --full-refresh dbt-duckdb:build
+	meltano run tap-spreadsheets-anywhere add-timestamps target-duckdb --full-refresh dbt-duckdb:build
 
 parquet:
-	meltano run tap-spreadsheets-anywhere target-parquet --full-refresh;\
+	meltano run tap-spreadsheets-anywhere add-timestamps target-parquet --full-refresh;\
 	meltano invoke dbt-duckdb build --target parquet
 
 pipeline:
-	meltano run tap-spreadsheets-anywhere target-duckdb --full-refresh;\
+	meltano run tap-spreadsheets-anywhere add-timestamps target-duckdb --full-refresh;\
 	meltano invoke dbt-duckdb run-operation elo_rollforward;\
 	meltano run dbt-duckdb:build

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ meltano run superset:ui
 ## Running your pipeline on demand
 After your run ```make pipeline```, you can run your pipeline again at any time with the following meltano command:
 ```
-meltano run tap-spreadsheets-anywhere target-duckdb --full-refresh dbt-duckdb:build
+meltano run tap-spreadsheets-anywhere add-timestamps target-duckdb --full-refresh dbt-duckdb:build
 ```
 
 ## Using Parquet instead of a database

--- a/meltano.yml
+++ b/meltano.yml
@@ -121,7 +121,7 @@ plugins:
   mappers:
     - name: meltano-map-transformer
       variant: meltano
-      pip_url: git+https://github.com/MeltanoLabs/meltano-map-transform.git
+      pip_url: git+https://github.com/MeltanoLabs/meltano-map-transform.git@chore-sdk-v0.14.0
 schedules:
 - name: spreadsheets-anywhere-to-duckdb
   interval: '@once'

--- a/meltano.yml
+++ b/meltano.yml
@@ -118,6 +118,10 @@ plugins:
         executable: dbt_extension
       build-parquet:
         args: build --target parquet
+  mappers:
+    - name: meltano-map-transformer
+      variant: meltano
+      pip_url: git+https://github.com/MeltanoLabs/meltano-map-transform.git
 schedules:
 - name: spreadsheets-anywhere-to-duckdb
   interval: '@once'

--- a/meltano.yml
+++ b/meltano.yml
@@ -62,6 +62,13 @@ plugins:
       file_size: 100000
       compression_method: snappy
       streams_in_separate_folder: true
+  # To aid in EL debugging:
+  - name: target-jsonl
+    variant: andyh1203
+    pip_url: target-jsonl
+    config:
+      output: $MELTANO_PROJECT_ROOT/output
+      do_timestamp_file: true
   utilities:
   - name: superset
     variant: apache
@@ -119,9 +126,27 @@ plugins:
       build-parquet:
         args: build --target parquet
   mappers:
-    - name: meltano-map-transformer
-      variant: meltano
-      pip_url: git+https://github.com/MeltanoLabs/meltano-map-transform.git@chore-sdk-v0.14.0
+  - name: meltano-map-transformer
+    variant: meltano
+    pip_url: git+https://github.com/MeltanoLabs/meltano-map-transform.git@chore-sdk-v0.14.0
+    mappings:
+    - name: add-timestamps
+      # Debug by running:
+      # % meltano run --full-refresh tap-spreadsheets-anywhere add-timestamps target-jsonl
+      config:
+        stream_maps:
+          latest_RAPTOR_by_player:
+            _sdc_extracted_at: datetime.datetime.utcnow().isoformat()
+          latest_RAPTOR_by_team:
+            _sdc_extracted_at: datetime.datetime.utcnow().isoformat()
+          nba_elo_latest:
+            _sdc_extracted_at: datetime.datetime.utcnow().isoformat()
+          nba_schedule_2023:
+            _sdc_extracted_at: datetime.datetime.utcnow().isoformat()
+          team_ratings:
+            _sdc_extracted_at: datetime.datetime.utcnow().isoformat()
+          xf_series_to_seed:
+            _sdc_extracted_at: datetime.datetime.utcnow().isoformat()
 schedules:
 - name: spreadsheets-anywhere-to-duckdb
   interval: '@once'

--- a/meltano.yml
+++ b/meltano.yml
@@ -131,6 +131,7 @@ plugins:
     pip_url: git+https://github.com/MeltanoLabs/meltano-map-transform.git@chore-sdk-v0.14.0
     mappings:
     - name: add-timestamps
+      # This adds timestamp columns to all of the named streams
       # Debug by running:
       # % meltano run --full-refresh tap-spreadsheets-anywhere add-timestamps target-jsonl
       config:
@@ -162,13 +163,13 @@ project_id: 0f7b47e6-7268-4193-9522-1773c1ee9fee
 jobs:
 - name: run-all
   tasks:
-  - tap-spreadsheets-anywhere target-duckdb dbt-duckdb:build
+  - tap-spreadsheets-anywhere add-timestamps target-duckdb dbt-duckdb:build
 - name: run-parquet
   tasks:
-  - tap-spreadsheets-anywhere target-parquet
+  - tap-spreadsheets-anywhere add-timestamps target-parquet
   - dbt-duckdb:build-parquet
 - name: pipeline
   tasks:
-  - tap-spreadsheets-anywhere target-duckdb
+  - tap-spreadsheets-anywhere add-timestamps target-duckdb
   - dbt-duckdb:run-elo_rollforward
   - dbt-duckdb:build

--- a/plugins/loaders/target-jsonl--andyh1203.lock
+++ b/plugins/loaders/target-jsonl--andyh1203.lock
@@ -1,0 +1,32 @@
+{
+  "plugin_type": "loaders",
+  "name": "target-jsonl",
+  "namespace": "target_jsonl",
+  "variant": "andyh1203",
+  "label": "JSON Lines (JSONL)",
+  "docs": "https://hub.meltano.com/loaders/target-jsonl--andyh1203",
+  "repo": "https://github.com/andyh1203/target-jsonl",
+  "pip_url": "target-jsonl",
+  "settings": [
+    {
+      "name": "destination_path",
+      "kind": "string",
+      "value": "output",
+      "label": "Destination Path",
+      "description": "Sets the destination path the JSONL files are written to, relative\nto the project root.\n\nThe directory needs to exist already, it will not be created\nautomatically.\n\nTo write JSONL files to the project root, set an empty string (`\"\"`).\n"
+    },
+    {
+      "name": "do_timestamp_file",
+      "kind": "boolean",
+      "value": false,
+      "label": "Include Timestamp in File Names",
+      "description": "Specifies if the files should get timestamped.\n\nBy default, the resulting file will not have a timestamp in the file name (i.e. `exchange_rate.jsonl`).\n\nIf this option gets set to `true`, the resulting file will have a timestamp associated with it (i.e. `exchange_rate-{timestamp}.jsonl`).\n"
+    },
+    {
+      "name": "custom_name",
+      "kind": "string",
+      "label": "Custom File Name Override",
+      "description": "Specifies a custom name for the filename, instead of the stream name.\n\nThe file name will be `{custom_name}-{timestamp}.jsonl`, if `do_timestamp_file` is `true`.\nOtherwise the file name will be `{custom_name}.jsonl`.\n\nIf custom name is not provided, the stream name will be used.\n"
+    }
+  ]
+}

--- a/plugins/mappers/meltano-map-transformer--meltano.lock
+++ b/plugins/mappers/meltano-map-transformer--meltano.lock
@@ -1,0 +1,11 @@
+{
+  "plugin_type": "mappers",
+  "name": "meltano-map-transformer",
+  "namespace": "meltano_map_transformer",
+  "variant": "meltano",
+  "label": "meltano-map-transformer",
+  "docs": "https://hub.meltano.com/mappers/meltano-map-transformer--meltano",
+  "repo": "https://github.com/MeltanoLabs/meltano-map-transform",
+  "pip_url": "git+https://github.com/MeltanoLabs/meltano-map-transform.git",
+  "executable": "meltano-map-transform"
+}


### PR DESCRIPTION
I've kept the commits fairly tidy so this is easier to follow. Basically:

1. Add the mapper: `meltano add mapper meltano-map-transformer`
2. For testing: `meltano add loader target-jsonl`
3. Add the `mappings` declaration for `add-timestamps` manually in yaml.
4. Test by sending the output to `target-jsonl`: `meltan run tap-spreadsheets-anywhere add-timestamps target-jsonl`
5. When it's working properly, add everywhere after `tap-spreadsheets-anywhere` is referenced in `meltano run`, Meltano job definitions, Makefile, CI jobs, etc.

```yml
plugins:
  mappers:
  - name: meltano-map-transformer
    # ...
    mappings:
    - name: add-timestamps
      # This adds timestamp columns to all of the named streams
      # Debug by running:
      # % meltano run --full-refresh tap-spreadsheets-anywhere add-timestamps target-jsonl
      config:
        stream_maps:
          sample_stream_a:
            _sdc_extracted_at: datetime.datetime.utcnow().isoformat()
          sample_stream_b:
            _sdc_extracted_at: datetime.datetime.utcnow().isoformat()
          # ...
```

